### PR TITLE
Replace deprecated gulp-util

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var gutil = require('gulp-util');
+var PluginError = require('plugin-error');
 var through = require('through2');
 var tidy = require('htmltidy2').tidy;
 
@@ -16,13 +16,13 @@ module.exports = function(opt){
         }
 
         if (file.isStream()) {
-            this.emit('error', new gutil.PluginError('gulp-htmltidy', 'Streaming not supported'));
+            this.emit('error', new PluginError('gulp-htmltidy', 'Streaming not supported'));
             return cb();
         }
 
         tidy(file.contents, opt, function (err, html) {
             if (err) {
-                this.emit('error', new gutil.PluginError('gulp-htmltidy', err));
+                this.emit('error', new PluginError('gulp-htmltidy', err));
             }
 
             file.contents = new Buffer(String(html));

--- a/package.json
+++ b/package.json
@@ -23,13 +23,13 @@
   },
   "homepage": "https://github.com/ayhankuru/gulp-htmltidy",
   "dependencies": {
-    "gulp-util": "^3.0.8",
     "htmltidy2": "*",
+    "plugin-error": "^1.0.1",
     "through2": "^2.0.3"
   },
   "devDependencies": {
     "expect.js": "^0.3.1",
-    "gulp-util": "^3.0.4",
-    "mocha": "^3.2.0"
+    "mocha": "^3.2.0",
+    "vinyl": "^2.1.0"
   }
 }

--- a/test/main.js
+++ b/test/main.js
@@ -1,6 +1,6 @@
 var expect = require('expect.js');
 var fs = require('fs');
-var gutil = require('gulp-util');
+var Vinyl = require('vinyl');
 var htmltidy = require('../index.js');
 
 it('Htmltidy Test', function (cb) {
@@ -16,7 +16,7 @@ it('Htmltidy Test', function (cb) {
 
 	stream.on('end', cb);
 
-	stream.write(new gutil.File({
+	stream.write(new Vinyl({
 		cwd: __dirname,
 		base: __dirname + '/fixtures',
 		path: __dirname + '/fixtures/test.html',


### PR DESCRIPTION
[`gulp-util`](https://www.npmjs.com/package/gulp-util) has been deprecated recently. Continuing to use this dependency may prevent the use of your library with the recently released version 4 of Gulp, **it is important to replace `gulp-util`**.

Your package is still relying on `gulp-util`, it would be good to publish a fixed version to npm as soon as possible.

See:
- https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
- https://github.com/gulpjs/gulp-util/issues/143